### PR TITLE
Added namespace variable for Servicemonitor object

### DIFF
--- a/helm/values/exporter/values.yaml
+++ b/helm/values/exporter/values.yaml
@@ -104,7 +104,7 @@ serviceMonitor:
   enabled: true
   interval: 30s
   scrapeTimeout: 10s
-  namespace: "monitoring"
+  namespace: "${service_monitor_namespace}"
   additionalLabels:
     release: prometheus-operator
   targetLabels: {}

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ resource "helm_release" "mongodb_exporter" {
   values = [
     templatefile("${path.module}/helm/values/exporter/values.yaml", {
       mongodb_exporter_password = "${random_password.mongodb_exporter_password.result}"
+      service_monitor_namespace = var.namespace
     }),
     var.mongodb_config.values_yaml
   ]


### PR DESCRIPTION
What: Added variables for servicemonitor

Why: The namespace to create servicemonitor was hardcoded hence resources are conflicting if the module is called in Demo modules. 
